### PR TITLE
Update Crystal dependency declaration in shards.yml to include Crystal >= 1.0.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,6 @@ version: 0.1.0
 authors:
   - Brian J. Cardiff <bcardiff@manas.tech>
 
-crystal: 0.34.0
+crystal: ">= 0.34.0, < 2.0.0"
 
 license: MIT


### PR DESCRIPTION
Projects that are depending on this library [cannot be built](https://github.com/crystal-lang/shards/issues/413) correctly because of [an implicit dependency](https://github.com/crystal-lang/shards/blob/master/docs/shard.yml.adoc#optional-attributes) on Crystal _<= 0.x_ in the [shards.yml](shards.yml) file. Test are passing fine with Crystal 1.0.0.